### PR TITLE
feat(schedule): allow schedule object syntax

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -119,15 +119,16 @@ class Scheduler {
   }
 
   _convertScheduleToCron(scheduleEvent) {
-    const params = scheduleEvent
+    const frequency = typeof(scheduleEvent === 'object') ? scheduleEvent.rate : scheduleEvent;
+    const params = frequency
       .replace('rate(', '')
       .replace('cron(', '')
       .replace(')', '');
 
-    if (scheduleEvent.startsWith('cron(')) {
+    if (frequency.startsWith('cron(')) {
       return params;
     }
-    if (scheduleEvent.startsWith('rate(')) {
+    if (frequency.startsWith('rate(')) {
       return this._convertRateToCron(params);
     }
 


### PR DESCRIPTION
Scheduled event can be a string or an object: https://serverless.com/framework/docs/providers/aws/events/schedule#enabling--disabling