### PR TITLE
Fixes scheduler not starting with serverless-offline

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ class ServerlessOfflineScheduler {
     };
     this.hooks = {
       "schedule:run": () => this.scheduler.run(),
-      "after:offline:start:init": () => this.scheduler.run()
+      "before:offline:start:init": () => this.scheduler.run()
     };
   }
 }


### PR DESCRIPTION
Running the scheduler standalone with `serverless schedule` works fine, but when running `serverless offline start` the scheduler doesn't get started because it needs to be called `before` the offline hook instead of `after`, this PR resolves that problem.