### PR TITLE
method to convert cron expression from AWS to node-schedule syntax

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -135,6 +135,15 @@ class Scheduler {
     return null;
   }
 
+  _convertCronSyntax(cronString) {
+    const CRON_LENGTH_WITH_YEAR = 6;
+    if (cronString.split(" ").length < CRON_LENGTH_WITH_YEAR) {
+      return cronString;
+    }
+
+    return cronString.replace(/\s\S+$/, "");
+  }
+
   _convertExpressionToCron(scheduleEvent) {
     const params = scheduleEvent
       .replace("rate(", "")
@@ -142,7 +151,7 @@ class Scheduler {
       .replace(")", "");
 
     if (scheduleEvent.startsWith("cron(")) {
-      return params;
+      return this._convertCronSyntax(params);
     }
     if (scheduleEvent.startsWith("rate(")) {
       return this._convertRateToCron(params);

--- a/tests/scheduler.test.js
+++ b/tests/scheduler.test.js
@@ -45,7 +45,7 @@ describe("validate", () => {
     expect(result).to.eql("1/* * * * *");
 
     result = module._convertExpressionToCron("cron(15 10 ? * 6L 2002-2005)");
-    expect(result).to.eql("15 10 ? * 6L 2002-2005");
+    expect(result).to.eql("15 10 ? * 6L");
   });
 
   it("should parse cron from object syntax", () => {


### PR DESCRIPTION
Currently the cron syntax used for node-schedule differs from the syntax used for AWS, in the case of a cron expression with 6 fields.

AWS starts with a minute field, and ends with a year field - [see here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions)
```
*    *    *    *    *    *
┬    ┬    ┬    ┬    ┬    ┬
│    │    │    │    │    |
│    │    │    │    │    └ year (1970-2199)
│    │    │    │    └───── day of week (0 - 7) (0 or 7 is Sun)
│    │    │    └────────── month (1 - 12)
│    │    └─────────────── day of month (1 - 31)
│    └──────────────────── hour (0 - 23)
└───────────────────────── minute (0 - 59)
```
node-schedule starts with a second field, and ends with a day-of-week field - [see here](https://github.com/node-schedule/node-schedule#cron-style-scheduling)
```
*    *    *    *    *    *
┬    ┬    ┬    ┬    ┬    ┬
│    │    │    │    │    |
│    │    │    │    │    └ day of week (0 - 7) (0 or 7 is Sun)
│    │    │    │    └───── month (1 - 12)
│    │    │    └────────── day of month (1 - 31)
│    │    └─────────────── hour (0 - 23)
│    └──────────────────── minute (0 - 59)
└───────────────────────── second (0 - 59, OPTIONAL)
```

This difference is not taken into account when converting the expression to cron, meaning the intended minute field is being interpreted as a second field.

This PR addresses the issue by checking if the input expression has six fields, and removing the last field (year) if it is present. The resulting expression is correctly handled by node-schedule.

I've updated the related test - if you want me to add more, let me know!