### PR TITLE
ADD: return schedule's input if exists

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -48,7 +48,7 @@ class Scheduler {
           }
           this.serverless.cli.log(`scheduler: running scheduled job: ${fConfig.id}`);
           func(
-            this._getEvent(),
+            this._getEvent(eventData.input),
             this._getContext(fConfig.id),
             () => {}
           );
@@ -79,7 +79,11 @@ class Scheduler {
     Object.assign(process.env, providerEnvVars, functionEnvVars);
   }
 
-  _getEvent() {
+  _getEvent(input) {
+    if (input) {
+      return input;
+    }
+    
     return {
       "account": "123456789012",
       "region": "serverless-offline",

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -83,7 +83,7 @@ class Scheduler {
     if (input) {
       return input;
     }
-    
+
     return {
       "account": "123456789012",
       "region": "serverless-offline",


### PR DESCRIPTION
ajmath, thx for your `serverless-offline-scheduler`, it is good for development on local.

According to test on AWS, event should be as same as the value of `input`,
the modification is used to simulate the result of AWS,
we can use `input` as parameters for scheduler

```
module.exports.test = (event, context, callback) => {
  //this event is referred by the value of input
  console.log(JSON.stringify(event, 2, 2))
};
```