### PR TITLE
ADD: return schedule's input if exists

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -10,7 +10,10 @@ class EventData {
   constructor(name, cron, enabled, input) {
     this.name = name;
     this.cron = cron;
-    this.enabled = enabled === undefined || enabled === null ? true : false;
+    this.enabled = enabled;
+    if (enabled == undefined || enabled == null) {
+      this.enabled = true;
+    }
     if (input) {
       this.input = input;
     }

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -48,7 +48,7 @@ class Scheduler {
           }
           this.serverless.cli.log(`scheduler: running scheduled job: ${fConfig.id}`);
           func(
-            this._getEvent(),
+            this._getEvent(eventData.input),
             this._getContext(fConfig.id),
             () => {}
           );
@@ -79,7 +79,11 @@ class Scheduler {
     Object.assign(process.env, providerEnvVars, functionEnvVars);
   }
 
-  _getEvent() {
+  _getEvent(input) {
+    if (input) {
+      return input;
+    }
+
     return {
       "account": "123456789012",
       "region": "serverless-offline",

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -11,7 +11,7 @@ class EventData {
     this.name = name;
     this.cron = cron;
     this.enabled = enabled;
-    if (enabled == undefined || enabled == null) {
+    if (enabled === undefined || enabled === null) {
       this.enabled = true;
     }
     if (input) {
@@ -189,7 +189,11 @@ class Scheduler {
   }
 
   _parseScheduleObject(funcName, rawEvent) {
-    return new EventData(funcName, this._convertExpressionToCron(rawEvent.rate), rawEvent.enabled, rawEvent.input);
+    return new EventData(
+      funcName,
+      this._convertExpressionToCron(rawEvent.rate),
+      rawEvent.enabled,
+      rawEvent.input);
   }
 
   _parseScheduleExpression(funcName, expression) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -186,7 +186,7 @@ class Scheduler {
   }
 
   _parseScheduleObject(funcName, rawEvent) {
-    return new EventData(funcName, this._convertExpressionToCron(rawEvent.rate));
+    return new EventData(funcName, this._convertExpressionToCron(rawEvent.rate), rawEvent.enabled, rawEvent.input);
   }
 
   _parseScheduleExpression(funcName, expression) {

--- a/tests/scheduler.test.js
+++ b/tests/scheduler.test.js
@@ -126,7 +126,7 @@ describe("validate", () => {
 
     const event2 = funcs[1].events[0];
     expect(event2).to.have.property("name").that.equals("scheduled2");
-    expect(event2).to.have.property("enabled").that.equals(true);
+    expect(event2).to.have.property("enabled").that.equals(false);
     expect(event2).to.have.property("cron").that.equals("0 */2 * * *");
 
     const event3 = funcs[1].events[1];

--- a/tests/scheduler.test.js
+++ b/tests/scheduler.test.js
@@ -134,4 +134,32 @@ describe("validate", () => {
     expect(event3).to.have.property("enabled").that.equals(true);
     expect(event3).to.have.property("cron").that.equals("1/* * * * *");
   });
+
+  it("should load functions with schedule events", () => {
+    module.serverless.service.functions = {
+      scheduled1: {
+        handler: "handler.test1",
+        events: [{
+          schedule: {
+            rate: "cron(1/* * * * *)",
+            input: {
+              key1: "value1"
+            }
+          }
+        }]
+      }
+    };
+
+    const funcs = module._getFuncConfigs();
+
+    expect(funcs[0]).to.have.property("id").that.equals("scheduled1");
+    expect(funcs[0]).to.have.property("events");
+
+    expect(funcs[0].events).to.have.lengthOf(1);
+
+    const event = funcs[0].events[0];
+    expect(event).to.have.property("cron").that.equals("1/* * * * *");
+    expect(event).to.have.property("input");
+    expect(event.input).to.have.property("key1").that.equals("value1");
+  });
 });


### PR DESCRIPTION
ajmath, thx for your `serverless-offline-scheduler`, it is good for development on local.

According to test on AWS, event should be as same as the value of `input`,
the modification is used to simulate the result of AWS,
we can use `input` as parameters for scheduler

```
module.exports.test = (event, context, callback) => {
  //this event is referred by the value of input
  console.log(JSON.stringify(event, 2, 2))
};
```