### PR TITLE
Implement `context.getRemainingTimeInMillis`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  node:
+    version: 4.8
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -6,8 +6,8 @@ const fs = require("fs");
 const schedule = require("node-schedule");
 const utils = require("./utils");
 
-const defaultTimeout = 6;
-const msPerSecond = 1000;
+const DEFAULT_TIMEOUT = 6;
+const MS_PER_SEC = 1000;
 
 class EventData {
   constructor(name, cron, enabled, input) {
@@ -111,7 +111,10 @@ class Scheduler {
   _getContext(fConfig) {
 
     const functionName = fConfig.id;
-    const endTime = Math.max(0, Date.now() + (fConfig.timeout || defaultTimeout) * msPerSecond);
+
+    const timeout = fConfig.timeout || this.serverless.service.provider.timeout || DEFAULT_TIMEOUT;
+
+    const endTime = Math.max(0, Date.now() + timeout * MS_PER_SEC);
 
     return {
       awsRequestId: utils.guid(),

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -6,6 +6,9 @@ const fs = require("fs");
 const schedule = require("node-schedule");
 const utils = require("./utils");
 
+const defaultTimeout = 6;
+const msPerSecond = 1000;
+
 class EventData {
   constructor(name, cron, enabled, input) {
     this.name = name;
@@ -35,6 +38,7 @@ class Scheduler {
       this.location = offlinePlugin.options.location;
     }
     this.funcConfigs = this._getFuncConfigs();
+
     for (const i in this.funcConfigs) {
       const fConfig = this.funcConfigs[i];
       for (const j in fConfig.events) {
@@ -52,7 +56,7 @@ class Scheduler {
           this.serverless.cli.log(`scheduler: running scheduled job: ${fConfig.id}`);
           func(
             this._getEvent(eventData.input),
-            this._getContext(fConfig.id),
+            this._getContext(fConfig),
             () => {}
           );
         });
@@ -104,7 +108,11 @@ class Scheduler {
     };
   }
 
-  _getContext(functionName) {
+  _getContext(fConfig) {
+
+    const functionName = fConfig.id;
+    const endTime = Math.max(0, Date.now() + (fConfig.timeout || defaultTimeout) * msPerSecond);
+
     return {
       awsRequestId: utils.guid(),
       invokeid: utils.guid(),
@@ -115,7 +123,8 @@ class Scheduler {
       functionName,
       memoryLimitInMB: "1024",
       callbackWaitsForEmptyEventLoop: true,
-      invokedFunctionArn: `arn:aws:lambda:serverless-offline:123456789012:function:${functionName}`
+      invokedFunctionArn: `arn:aws:lambda:serverless-offline:123456789012:function:${functionName}`,
+      getRemainingTimeInMillis: () => endTime - Date.now()
     };
   }
 
@@ -171,6 +180,7 @@ class Scheduler {
   _getFuncConfigs() {
     const funcConfs = [];
     const inputfuncConfs = this.serverless.service.functions;
+
     for (const funcName in inputfuncConfs) {
       const funcConf = inputfuncConfs[funcName];
       const scheduleEvents = funcConf.events
@@ -181,6 +191,7 @@ class Scheduler {
         funcConfs.push({
           id: funcName,
           events: scheduleEvents,
+          timeout: funcConf.timeout,
           moduleName: funcConf.handler.split(".")[0]
         });
       }

--- a/tests/scheduler.test.js
+++ b/tests/scheduler.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 
 const Scheduler = require("../lib/scheduler");
 
-const msPerSecond = 1000;
+const MS_PER_SEC = 1000;
 
 describe("validate", () => {
   let module;
@@ -165,7 +165,7 @@ describe("validate", () => {
     expect(event.input).to.have.property("key1").that.equals("value1");
   });
 
-  it("should correctly", () => {
+  it("should use the *function* timeout for getRemainingTimeInMillis", () => {
 
     const timeout = 45; // secs
     const maxDuration = 2; // msecs
@@ -184,7 +184,52 @@ describe("validate", () => {
 
     const funcs = module._getFuncConfigs();
     const context = module._getContext(funcs[0]);
-    expect(context.getRemainingTimeInMillis()).to.be.at.most(timeout * msPerSecond);
-    expect(context.getRemainingTimeInMillis()).to.be.at.least(timeout * msPerSecond - maxDuration);
+    expect(context.getRemainingTimeInMillis()).to.be.at.most(timeout * MS_PER_SEC);
+    expect(context.getRemainingTimeInMillis()).to.be.at.least(timeout * MS_PER_SEC - maxDuration);
+  });
+
+  it("should use the *provider* timeout for getRemainingTimeInMillis", () => {
+
+    const timeout = 35; // secs
+    const maxDuration = 2; // msecs
+
+    module.serverless.service.provider.timeout = timeout;
+    module.serverless.service.functions = {
+      scheduled1: {
+        handler: "handler.test1",
+        events: [{
+          schedule: {
+            rate: "cron(1/* * * * *)"
+          }
+        }]
+      }
+    };
+
+    const funcs = module._getFuncConfigs();
+    const context = module._getContext(funcs[0]);
+    expect(context.getRemainingTimeInMillis()).to.be.at.most(timeout * MS_PER_SEC);
+    expect(context.getRemainingTimeInMillis()).to.be.at.least(timeout * MS_PER_SEC - maxDuration);
+  });
+
+  it("should use the *default* timeout for getRemainingTimeInMillis", () => {
+
+    const timeout = 6; // secs
+    const maxDuration = 2; // msecs
+
+    module.serverless.service.functions = {
+      scheduled1: {
+        handler: "handler.test1",
+        events: [{
+          schedule: {
+            rate: "cron(1/* * * * *)"
+          }
+        }]
+      }
+    };
+
+    const funcs = module._getFuncConfigs();
+    const context = module._getContext(funcs[0]);
+    expect(context.getRemainingTimeInMillis()).to.be.at.most(timeout * MS_PER_SEC);
+    expect(context.getRemainingTimeInMillis()).to.be.at.least(timeout * MS_PER_SEC - maxDuration);
   });
 });

--- a/tests/scheduler.test.js
+++ b/tests/scheduler.test.js
@@ -7,6 +7,8 @@ const expect = chai.expect;
 
 const Scheduler = require("../lib/scheduler");
 
+const msPerSecond = 1000;
+
 describe("validate", () => {
   let module;
   let serverless;
@@ -161,5 +163,28 @@ describe("validate", () => {
     expect(event).to.have.property("cron").that.equals("1/* * * * *");
     expect(event).to.have.property("input");
     expect(event.input).to.have.property("key1").that.equals("value1");
+  });
+
+  it("should correctly", () => {
+
+    const timeout = 45; // secs
+    const maxDuration = 2; // msecs
+
+    module.serverless.service.functions = {
+      scheduled1: {
+        handler: "handler.test1",
+        timeout,
+        events: [{
+          schedule: {
+            rate: "cron(1/* * * * *)"
+          }
+        }]
+      }
+    };
+
+    const funcs = module._getFuncConfigs();
+    const context = module._getContext(funcs[0]);
+    expect(context.getRemainingTimeInMillis()).to.be.at.most(timeout * msPerSecond);
+    expect(context.getRemainingTimeInMillis()).to.be.at.least(timeout * msPerSecond - maxDuration);
   });
 });


### PR DESCRIPTION
This PR implements the missing context method `context.getRemainingTimeInMillis` which returns the number of milliseconds remaining before the function will exit with a timeout (see [docs](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html#nodejs-prog-model-context-methods-getRemainingTimeInMillis-nodejs)) plus the relevant tests.

It uses the same essential logic [as seen in serverless-offline](https://github.com/dherault/serverless-offline/blob/f230eaebd42406054486addbf94ef622024a9394/src/createLambdaContext.js#L12)

I have also specified a node version in `circle.yml` as `yarn` is no longer supported for `node` < 4.8.0 and tests were failing. See [related `yarnpkg` issue](https://github.com/yarnpkg/yarn/issues/4337)