### PR TITLE
Fixes Serverless Webpack watch

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -81,10 +81,15 @@ class Scheduler {
   }
 
   _setEnvironmentVars(functionName) {
+    const baseEnv = {
+      IS_LOCAL: true,
+      IS_OFFLINE: true
+    };
+
     const providerEnvVars = this.serverless.service.provider.environment || {};
     const functionEnvVars = this.serverless.service.functions[functionName].environment || {};
 
-    Object.assign(process.env, providerEnvVars, functionEnvVars);
+    Object.assign(process.env, baseEnv, providerEnvVars, functionEnvVars);
   }
 
   _getEvent(input) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -74,6 +74,7 @@ class Scheduler {
       this.serverless.config.servicePath,
       this.location || "", filename);
     if (fs.existsSync(funcPath)) {
+      delete require.cache[require.resolve(funcPath)];
       return require(funcPath)[handlerFunction];
     }
     return null;


### PR DESCRIPTION
It allows the latest file to be run by deleting require.cache