### PR TITLE
Use rule name when specified

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.8
+    version: 6.16
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -10,16 +10,14 @@ const DEFAULT_TIMEOUT = 6;
 const MS_PER_SEC = 1000;
 
 class EventData {
-  constructor(name, cron, enabled, input) {
-    this.name = name;
+  constructor(funcName, cron, {enabled = true, input, name = "my-schedule"} = {}) {
+    this.name = funcName;
     this.cron = cron;
     this.enabled = enabled;
-    if (enabled === undefined || enabled === null) {
-      this.enabled = true;
-    }
     if (input) {
       this.input = input;
     }
+    this.ruleName = name;
   }
 }
 
@@ -55,7 +53,7 @@ class Scheduler {
           }
           this.serverless.cli.log(`scheduler: running scheduled job: ${fConfig.id}`);
           func(
-            this._getEvent(eventData.input),
+            this._getEvent(eventData),
             this._getContext(fConfig),
             () => {}
           );
@@ -92,7 +90,7 @@ class Scheduler {
     Object.assign(process.env, baseEnv, providerEnvVars, functionEnvVars);
   }
 
-  _getEvent(input) {
+  _getEvent({input, ruleName}) {
     if (input) {
       return input;
     }
@@ -106,7 +104,7 @@ class Scheduler {
       "time": new Date().toISOString(),
       "id": utils.guid(),
       "resources": [
-        "arn:aws:events:serverless-offline:123456789012:rule/my-schedule"
+        `arn:aws:events:serverless-offline:123456789012:rule/${ruleName}`
       ],
       "isOffline": true,
       "stageVariables": this.serverless.service.custom
@@ -212,8 +210,8 @@ class Scheduler {
     return new EventData(
       funcName,
       this._convertExpressionToCron(rawEvent.rate),
-      rawEvent.enabled,
-      rawEvent.input);
+      rawEvent
+      );
   }
 
   _parseScheduleExpression(funcName, expression) {

--- a/tests/scheduler.test.js
+++ b/tests/scheduler.test.js
@@ -55,6 +55,7 @@ describe("validate", () => {
 
     expect(toCron({ rate: "rate(10 minutes)", enabled: true })).to.eql({
       name: "my-job",
+      ruleName: "my-schedule",
       cron: "*/10 * * * *",
       enabled: true
     });
@@ -130,6 +131,7 @@ describe("validate", () => {
     expect(event2).to.have.property("name").that.equals("scheduled2");
     expect(event2).to.have.property("enabled").that.equals(false);
     expect(event2).to.have.property("cron").that.equals("0 */2 * * *");
+    expect(event2).to.have.property("ruleName").that.equals("custom-name");
 
     const event3 = funcs[1].events[1];
     expect(event3).to.have.property("name").that.equals("scheduled2");


### PR DESCRIPTION
Serverless allows to specify the rule name. This PR makes serverless-offline-scheduler use that rule name in the resources arn in order to better reflect the live AWS behavior.
Closes #19 