### PR TITLE
Allow usage of default event input

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -8,16 +8,35 @@ const DEFAULT_TIMEOUT = 6;
 const MS_PER_SEC = 1000;
 
 class EventData {
-  constructor(funcName, cron, rawEvent) {
+  constructor(funcName, cron, stageVariables, rawEvent) {
     const event = rawEvent || {};
 
     this.name = funcName;
     this.cron = cron;
     this.enabled = event.enabled === undefined || event.enabled === null ? true : !!event.enabled;
-    if (event.input) {
-      this.input = event.input;
-    }
     this.ruleName = event.name || funcName;
+    this.rawInput = event.input;
+    this.stageVariables = stageVariables;
+    this.input = this._getEvent();
+  }
+
+  _getEvent() {
+    if (this.rawInput) {
+      return this.rawInput;
+    }
+
+    return {
+      account: "123456789012",
+      region: "serverless-offline",
+      detail: {},
+      "detail-type": "Scheduled Event",
+      source: "aws.events",
+      time: new Date().toISOString(),
+      id: utils.guid(),
+      resources: [`arn:aws:events:serverless-offline:123456789012:rule/${this.ruleName}`],
+      isOffline: true,
+      stageVariables: this.stageVariables,
+    };
   }
 }
 
@@ -107,26 +126,6 @@ class Scheduler {
     const functionEnvVars = this.serverless.service.functions[functionName].environment || {};
 
     Object.assign(process.env, baseEnv, providerEnvVars, functionEnvVars);
-  }
-
-  _getEvent(args) {
-    if (args.input) {
-      return args.input;
-    }
-
-    return {
-      account: "123456789012",
-      region: "serverless-offline",
-      detail: {},
-      "detail-type": "Scheduled Event",
-      source: "aws.events",
-      time: new Date().toISOString(),
-      id: utils.guid(),
-      resources: [`arn:aws:events:serverless-offline:123456789012:rule/${args.ruleName}`],
-      isOffline: true,
-      stageVariables:
-        this.serverless.service.custom && this.serverless.service.custom.stageVariables
-    };
   }
 
   _getContext(fConfig) {
@@ -223,11 +222,15 @@ class Scheduler {
   }
 
   _parseScheduleObject(funcName, rawEvent) {
-    return new EventData(funcName, this._convertExpressionToCron(rawEvent.rate), rawEvent);
+    return new EventData(funcName, this._convertExpressionToCron(rawEvent.rate), this._getStageVariables(), rawEvent);
   }
 
   _parseScheduleExpression(funcName, expression) {
-    return new EventData(funcName, this._convertExpressionToCron(expression));
+    return new EventData(funcName, this._convertExpressionToCron(expression), this._getStageVariables());
+  }
+
+  _getStageVariables() {
+    return this.serverless.service.custom && this.serverless.service.custom.stageVariables;
   }
 
   _parseEvent(funcName, rawEvent) {


### PR DESCRIPTION
The default event is now `undefined` when no input is defined. This makes use of the default event definition again when the input is skipped.