### PR TITLE
Remove unused code that is preventing to work with serverless-offline >=6.

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -44,24 +44,13 @@ class Scheduler {
   constructor(serverless, options = {}) {
     this.serverless = serverless;
     this.options = options;
-    this.location = "";
     this.run = this.run.bind(this);
     this._getFuncConfigs = this._getFuncConfigs.bind(this);
   }
 
   run(opts) {
     const options = Object.assign(this.options, opts);
-    const offlinePlugin = this.serverless.pluginManager
-      .getPlugins()
-      .find(
-        (p) =>
-          p.constructor &&
-          (p.constructor.name === "ServerlessOffline" || p.constructor.name === "Offline")
-      );
 
-    if (offlinePlugin) {
-      this.location = offlinePlugin.options.location;
-    }
     this.funcConfigs = this._getFuncConfigs();
 
     for (const i in this.funcConfigs) {


### PR DESCRIPTION
The plugin is not working with serverless-offline >= 6 as this issue explained https://github.com/ajmath/serverless-offline-scheduler/issues/48

Checking the code, it seems that the location property is not used anywhere in the code, so, I removed it and the plugin now works with >= 6.