### PR TITLE
fix: predefine type for runScheduleOnInit option

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ class ServerlessOfflineScheduler {
             usage:
               "run scheduled functions immediately in addition to defined interval" +
               "(e.g \"--runSchedulesOnInit\")",
-            required: false
+            required: false,
+            type: "boolean"
           }
         }
       }


### PR DESCRIPTION
This PR aims to fix the warning generated by running the plugin.

The warning:
```
Serverless: Deprecation warning: CLI options definitions were upgraded with "type" property 
(which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine 
type for introduced options:
            - ServerlessOfflineScheduler for "runSchedulesOnInit"
            Please report this issue in plugin issue tracker.
            Starting with next major release, this will be communicated with a thrown error.
            More Info: https://www.serverless.com/framework/docs/deprecations/#CLI_OPTIONS_SCHEMA
```

Fixes #70 